### PR TITLE
refactor: use Set for vertices

### DIFF
--- a/lib/multi-edge-graph.class.js
+++ b/lib/multi-edge-graph.class.js
@@ -15,14 +15,15 @@ export default class Graph {
       implementada com o uso da classe Map nativa do JavaScript. 
     */
     this.isDirected = isDirected
-    this.vertices = []    // Array permite elementos repetidos
+    // Conjunto de vértices, evitando duplicatas
+    this.vertices = new Set()
     this.adjList = new Map()
   }
   // Método que adiciona um vértice ao grafo
   addVertex(v) {
-    // Adiciona o vértice ao array caso ainda não exista
-    if(! this.vertices.includes(v)) {
-      this.vertices.push(v)
+    // Adiciona o vértice ao conjunto caso ainda não exista
+    if(! this.vertices.has(v)) {
+      this.vertices.add(v)
 
   // Implementar o restante da classe, usando o vetor em
   // this.vertices
@@ -34,10 +35,10 @@ export default class Graph {
   // Método que adiciona uma aresta ao grafo
   addEdge(v, w) {   // v e w são vértices
     // Se o vértice v ainda não existe, cria-o
-    if(! this.vertices.includes(v)) this.addVertex(v)
+    if(! this.vertices.has(v)) this.addVertex(v)
 
     // Se o vértice w ainda não existe, cria-o
-    if(! this.vertices.includes(w)) this.addVertex(w)
+    if(! this.vertices.has(w)) this.addVertex(w)
 
     // Estabelece a aresta v -> w
     this.adjList.get(v).push(w)
@@ -50,7 +51,7 @@ export default class Graph {
   // Método que remove um vértice do grafo
   removeVertex(v) {
     // Age apenas se o vértice existir
-    if(! this.vertices.includes(v)) return
+    if(! this.vertices.has(v)) return
 
     let referenced = false
 
@@ -69,7 +70,7 @@ export default class Graph {
     if(this.adjList.get(v).length === 0 && !referenced) {
 
       // Remove o vértice da lista de vértices
-      this.vertices = this.vertices.filter(vtx => vtx !== v)
+      this.vertices.delete(v)
 
       // Remove a entrada da lista de adjacência
       this.adjList.delete(v)
@@ -80,7 +81,7 @@ export default class Graph {
   // Método que remove uma aresta do grafo
   removeEdge(v, w) {   // v e w são os vértices incidentes à aresta
     // Verifica se tanto v quanto w são vértices válidos
-    if(!(this.vertices.includes(v) && this.vertices.includes(w))) return
+    if(!(this.vertices.has(v) && this.vertices.has(w))) return
 
     // Exclui uma ocorrência de w da lista de adjacência de v
     const adjV = this.adjList.get(v)


### PR DESCRIPTION
## Summary
- replace vertex array with Set to avoid duplicates
- update graph methods to use Set operations

## Testing
- `node -e "import Graph from './lib/multi-edge-graph.class.js'; const g=new Graph(); g.addEdge('A','B'); g.addEdge('A','B'); console.log('AdjA:', g.adjList.get('A'));"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b76536bb908330817fceab91580018